### PR TITLE
Deleted client objects search

### DIFF
--- a/src/imem_dal_skvh.erl
+++ b/src/imem_dal_skvh.erl
@@ -997,7 +997,9 @@ find_deleted_objects(Table, Key , EndKey, <<>>, Limit, Acc) ->
         _ ->
             {Limit, Acc}
     end,
-    find_deleted_objects(Table, imem_meta:next(Table, Key), EndKey, <<>>, NewLimit, NewAcc);
+    NKey = imem_meta:next(Table, Key),
+    NextKey = find_next_objects(Table, NKey, EndKey),
+    find_deleted_objects(Table, NextKey, EndKey, <<>>, NewLimit, NewAcc);
 find_deleted_objects(Table, Key, EndKey, Text, Limit, Acc) ->
     {NewLimit, NewAcc} =  case imem_meta:read(Table, Key) of
         [#skvhHist{cvhist = [#skvhCL{ovalue = Value, nvalue = undefined}| _]}] ->

--- a/src/imem_dal_skvh.erl
+++ b/src/imem_dal_skvh.erl
@@ -116,8 +116,8 @@
         , hist_read_deleted/3 %% (User, Channel, Key)               return the oldvalue of the deleted object
         , hist_read_shallow/4 %% (User, Channel, Key, DelStatus)    return the shallow list of deleted objects
         , search_deleted/6  %% (User,s Channel, Ckey1, Ckey2, Text) from key at or after CKey1 to last key before CKey2, finds {K,V} with text in V
-        , search_deleted_clients/6
-        , search_deleted_objects/6
+        , search_deleted_clients/6 %% (User,s Channel, Ckey1, Ckey2, Text) from key at or after CKey1 to last key before CKey2, finds {K,V} with text in V in deleted clients
+        , search_deleted_objects/6 %% (User,s Channel, Ckey1, Ckey2, Text) from key at or after CKey1 to last key before CKey2, finds {K,V} with text in V in deleted objects
         , remove/3          %% (User, Channel, RowList)             delete a resource will fail if it was modified, rows should be in map format
         , remove/4          %% (User, Channel, RowList, Opts)       delete a resource will fail if it was modified, rows should be in map format, with trigger options
         , delete/3          %% (User, Channel, KeyTable)            do not complain if keys do not exist

--- a/src/imem_sql_select.erl
+++ b/src/imem_sql_select.erl
@@ -1309,11 +1309,11 @@ test_with_or_without_sec(IsSec) ->
         ),
 
         {timeout, 5, fun() -> 
-            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddViewTest;", 0, [{schema,imem}], IsSec)),
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddViewTest;", 0, [{schema,imem}], IsSec))
         end},
 
         {timeout, 5, fun() -> 
-            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddCmdTest;", 0, [{schema,imem}], IsSec)),
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddCmdTest;", 0, [{schema,imem}], IsSec))
         end},
 
 
@@ -1808,7 +1808,7 @@ test_with_or_without_sec(IsSec) ->
             ?assertEqual(ok, imem_sql:exec(SKey, "drop table member_test;", 0, [{schema,imem}], IsSec))
         end},
         {timeout, 5, fun() -> 
-            ?assertEqual(ok, imem_sql:exec(SKey, "drop table def;", 0, [{schema,imem}], IsSec)),
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table def;", 0, [{schema,imem}], IsSec))
         end},
 
         case IsSec of

--- a/src/imem_sql_select.erl
+++ b/src/imem_sql_select.erl
@@ -1308,9 +1308,14 @@ test_with_or_without_sec(IsSec) ->
             end
         ),
 
-        ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddViewTest;", 0, [{schema,imem}], IsSec)),
+        {timeout, 5, fun() -> 
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddViewTest;", 0, [{schema,imem}], IsSec)),
+        end},
 
-        ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddCmdTest;", 0, [{schema,imem}], IsSec)),
+        {timeout, 5, fun() -> 
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table ddCmdTest;", 0, [{schema,imem}], IsSec)),
+        end},
+
 
     %% sorting
 
@@ -1799,8 +1804,12 @@ test_with_or_without_sec(IsSec) ->
             ]
         ),
 
-        ?assertEqual(ok, imem_sql:exec(SKey, "drop table member_test;", 0, [{schema,imem}], IsSec)),
-        ?assertEqual(ok, imem_sql:exec(SKey, "drop table def;", 0, [{schema,imem}], IsSec)),
+        {timeout, 5, fun() -> 
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table member_test;", 0, [{schema,imem}], IsSec))
+        end},
+        {timeout, 5, fun() -> 
+            ?assertEqual(ok, imem_sql:exec(SKey, "drop table def;", 0, [{schema,imem}], IsSec)),
+        end},
 
         case IsSec of
             true ->     ?imem_logout(SKey);

--- a/src/imem_test.erl
+++ b/src/imem_test.erl
@@ -323,7 +323,6 @@ test(_) ->
             ?assertException(throw, {'ClientError',{"Table does not exist",user_table_123}}, imem_sec:table_size(SeCo4, user_table_123))
          end},
         ?LogDebug("success ~p~n", [drop_own_table]),
-        % ?assertException(throw, {'ClientError',{"Table does not exist",user_table_123}}, imem_sec:table_size(SeCo4, user_table_123)),    
         ?assertEqual(ok, imem_role:grant_role(SeCo, AccountId, table_creator)),
         ?LogDebug("success ~p~n", [role_grant_tc_role]),      
         ?assertEqual(ok, imem_role:create(SeCo, #ddRole{id=test_role,roles=[],permissions=[perform_tests]})),

--- a/src/imem_test.erl
+++ b/src/imem_test.erl
@@ -318,7 +318,7 @@ test(_) ->
         ?assertEqual({user_table_123,"AA","BB","CC"}, imem_sec:insert(SeCo4, user_table_123, {user_table_123,"AA","BB","CC"})),
         ?assertEqual(2, imem_sec:table_size(SeCo4, user_table_123)),
         ?LogDebug("success ~p~n", [insert_own_table]),
-        ?assertEqual(ok, imem_sec:drop_table(SeCo4, user_table_123)),
+        {timeout, 5, fun() -> ?assertEqual(ok, imem_sec:drop_table(SeCo4, user_table_123)) end},
         ?LogDebug("success ~p~n", [drop_own_table]),
         ?assertException(throw, {'ClientError',{"Table does not exist",user_table_123}}, imem_sec:table_size(SeCo4, user_table_123)),    
         ?assertEqual(ok, imem_role:grant_role(SeCo, AccountId, table_creator)),


### PR DESCRIPTION
Changes for fetching deleted objects.
Deleted object could be an active object of a deleted parent or deleted object.