### PR TITLE
read deep / shallow speedup

### DIFF
--- a/src/imem_dal_skvh.erl
+++ b/src/imem_dal_skvh.erl
@@ -797,11 +797,11 @@ read_shallow_single(Channel, TableName, CurrentKey, EndKey, KeyLen) ->
         '$end_of_table' -> [];
         NextKey when NextKey >= EndKey -> [];
         NextKey ->
-            [#skvhTable{ckey=EncodedKey} = Row] = imem_meta:read(TableName, NextKey),
-            CKey = imem_datatype:binterm_to_term(EncodedKey),
-            case length(CKey) =:= KeyLen of
+            case length(imem_datatype:binterm_to_term(NextKey)) =:= KeyLen of
                 false -> read_shallow_single(Channel, TableName, NextKey, EndKey, KeyLen);
-                true -> [skvh_rec_to_map(Row) | 
+                true ->
+                    [Row] = imem_meta:read(TableName, NextKey),
+                    [skvh_rec_to_map(Row) | 
                          read_shallow_single(Channel, TableName, NextKey, EndKey, KeyLen)]
             end
     end.

--- a/src/imem_dal_skvh.erl
+++ b/src/imem_dal_skvh.erl
@@ -777,25 +777,57 @@ read_siblings(User, Channel, [Key | Keys]) ->
     read_shallow(User, Channel, [lists:reverse(ParentKeyRev)])
     ++ read_siblings(User, Channel, Keys).
 
-read_shallow(_User, _Channel, []) -> [];
-read_shallow(User, Channel, [Key | Keys]) ->
-    KeyLen = length(binterm_to_term_key(Key)) + 1,
-    [SkvhRow || #{ckey := CK} = SkvhRow <- read_deep(User, Channel, [Key]),
-                length(CK) == KeyLen]
-    ++ read_shallow(User, Channel, Keys).
+read_shallow(User, Channel, Keys) ->
+    ReadShallowFun = fun() ->
+        read_shallow_internal(User, Channel, Keys)
+    end,
+    imem_meta:return_atomic(imem_meta:transaction(ReadShallowFun)).
 
-read_deep(_User, _Channel, []) -> [];
-read_deep(User, Channel, [Key | Keys]) ->
+read_shallow_internal(_User, _Channel, []) -> [];
+read_shallow_internal(User, Channel, [Key | Keys]) ->
+    KeyLen = length(binterm_to_term_key(Key)) + 1,
+    StartKey = term_key_to_binterm(Key),
+    EndKey = term_key_to_binterm(binterm_to_term_key(Key) ++ <<255>>),
+    TableName = atom_table_name(Channel),
+    read_shallow_single(Channel, TableName, StartKey, EndKey, KeyLen) ++ 
+        read_shallow_internal(User, Channel, Keys).
+
+read_shallow_single(Channel, TableName, CurrentKey, EndKey, KeyLen) ->
+    case imem_meta:next(TableName, CurrentKey) of
+        '$end_of_table' -> [];
+        NextKey when NextKey >= EndKey -> [];
+        NextKey ->
+            [#skvhTable{ckey=EncodedKey} = Row] = imem_meta:read(TableName, NextKey),
+            CKey = imem_datatype:binterm_to_term(EncodedKey),
+            case length(CKey) =:= KeyLen of
+                false -> read_shallow_single(Channel, TableName, NextKey, EndKey, KeyLen);
+                true -> [skvh_rec_to_map(Row) | 
+                         read_shallow_single(Channel, TableName, NextKey, EndKey, KeyLen)]
+            end
+    end.
+
+read_deep(User, Channel, Keys) ->
+    ReadDeepFun = fun() ->
+        read_deep_internal(User, Channel, Keys)
+    end,
+    imem_meta:return_atomic(imem_meta:transaction(ReadDeepFun)).
+
+read_deep_internal(_User, _Channel, []) -> [];
+read_deep_internal(User, Channel, [Key | Keys]) ->
     StartKey = term_key_to_binterm(Key),
     EndKey = term_key_to_binterm(binterm_to_term_key(Key) ++ <<255>>), % improper list [...|<<255>>]
     TableName = atom_table_name(Channel),
-    {SkvhRows, true} = imem_meta:select(
-                         TableName,
-                         [{#skvhTable{ckey='$1', cvalue = '$2', chash = '$3'},
-                           [{'andalso',{'>','$1',StartKey},{'<','$1',EndKey}}],
-                           ['$_']}]),
-    [skvh_rec_to_map(SkvhRow) || SkvhRow <- SkvhRows]
-    ++ read_deep(User, Channel, Keys).
+    read_deep_single(Channel, TableName, StartKey, EndKey) ++
+        read_deep_internal(User, Channel, Keys).
+
+read_deep_single(Channel, TableName, CurrentKey, EndKey) ->
+    case imem_meta:next(TableName, CurrentKey) of
+        '$end_of_table' -> [];
+        NextKey when NextKey >= EndKey -> [];
+        NextKey ->
+            [Row] = imem_meta:read(TableName, NextKey),
+            [skvh_rec_to_map(Row) | read_deep_single(Channel, TableName, NextKey, EndKey)]
+    end.
 
 % @doc Returnes the longest prefix >= startKey and =< EndKey
 -spec get_longest_prefix(User :: any(), Channel :: binary(),


### PR DESCRIPTION
Directly reading using imem_meta:next instead of using select, as it is faster.
Filter for shallow read without having to construct the maps for discarded results.

```
09:28:39.450 [info] [_SBS_] {sbs_dal,409} time read shallow count: 899, average: 34219.228031145714, total: 30.763086 (Seconds)
11:26:45.688 [info] [_SBS_] {sbs_dal,409} time read shallow count: 899, average: 205.2258064516129, total: 0.184498 (Seconds)
```

```
11:43:06.624 [info] [_SBS_] {sbs_dal,685} time read deep count: 899, average: 33930.34149054505, total: 30.503377 (Seconds)
11:59:41.704 [info] [_SBS_] {sbs_dal,685} time read deep count: 899, average: 4719.806451612903, total: 4.243106 (Seconds)
```