### PR TITLE
SAML auth support in imem

### DIFF
--- a/include/imem_seco.hrl
+++ b/include/imem_seco.hrl
@@ -11,7 +11,8 @@
                       | {scrypt,{binary(),binary()}}  % {scrypt,{Salt,Hash}}    in ddAccount.credentials 
                       | {access,map()}                % {access,NetworkCtx}                   input to auth_start / auth_add_cred
                       | {pwdmd5,{binary(),binary()}}  % {pwdmd5, {AccountName,md5(password)}  input to auth_start / auth_add_cred
-                      | {smsott,binary()}.            % {smsott,Token}                        input to auth_start / auth_add_cred 
+                      | {smsott,binary()}             % {smsott,Token}                        input to auth_start / auth_add_cred 
+                      | {saml,binary()}.              % {saml, AccountName}                   input to auth_start / auth_add_cred 
 
 -type ddCredRequest() :: {pwdmd5,map()}               % {pwdmd5,#{}} | {smsott,#{accountName=>AccountName}} (any / fixed AccountName) 
                        | {smsott,map()}               % {smsott,#{accountName=>AccountName,to=>To}}

--- a/src/imem_seco.erl
+++ b/src/imem_seco.erl
@@ -593,10 +593,10 @@ auth_step(SeCo, {smsott,Token}) ->
 auth_step(SeCo, {saml, Name}) ->
     #ddSeCo{skey=SKey, accountId=AccountId0, authFactors=AFs} = SeCo, % may not yet exist in ddSeco@
     case if_select_account_by_name(SKey, Name) of
-        {[#ddAccount{locked='true'}],true} ->
-            authenticate_fail(SeCo, "Account is locked. Contact a system administrator", true);
         {[#ddAccount{id=AccountId1}],true} when AccountId0==AccountId1; AccountId0==undefined ->
             auth_step_succeed(SeCo#ddSeCo{accountName=Name, accountId=AccountId1, authFactors=[saml|AFs]});
+        {[#ddAccount{locked='true'}],true} ->
+            authenticate_fail(SeCo, "Account is locked. Contact a system administrator", true);
         {[#ddAccount{}],true} -> 
             authenticate_fail(SeCo, "Account name conflict", true);
         {[],true} ->

--- a/src/imem_seco.erl
+++ b/src/imem_seco.erl
@@ -590,6 +590,18 @@ auth_step(SeCo, {smsott,Token}) ->
                     end
             end
     end;
+auth_step(SeCo, {saml, Name}) ->
+    #ddSeCo{skey=SKey, accountId=AccountId0, authFactors=AFs} = SeCo, % may not yet exist in ddSeco@
+    case if_select_account_by_name(SKey, Name) of
+        {[#ddAccount{locked='true'}],true} ->
+            authenticate_fail(SeCo, "Account is locked. Contact a system administrator", true);
+        {[#ddAccount{id=AccountId1}],true} when AccountId0==AccountId1; AccountId0==undefined ->
+            auth_step_succeed(SeCo#ddSeCo{accountName=Name, accountId=AccountId1, authFactors=[saml|AFs]});
+        {[#ddAccount{}],true} -> 
+            authenticate_fail(SeCo, "Account name conflict", true);
+        {[],true} ->
+            authenticate_fail(SeCo, "Not a valid user", true)
+    end;
 auth_step(SeCo, Credential) ->
     authenticate_fail(SeCo,{"Invalid credential type",element(1,Credential)}, true).
 


### PR DESCRIPTION
Fixes #99 

_to test  saml with user system_
```erlang
imem_meta:put_config_hlk(ddConfig, {imem,imem_seco,authenticateRequireFun}, system, [], <<"fun(Factors,NetCtx) -> [saml] -- Factors end">>, <<"changed">>).  
imem_seco:auth_start(imem, crypto:rand_bytes(64), {saml, <<"system">>}).
%changing the value back to default
imem_meta:put_config_hlk(ddConfig, {imem,imem_seco,authenticateRequireFun}, system, [], <<"fun(Factors,NetCtx) -> [pwdmd5] -- Factors end">>, <<"changed">>).  
```