### PR TITLE
pretty printing records

### DIFF
--- a/include/imem_meta.hrl
+++ b/include/imem_meta.hrl
@@ -3,6 +3,7 @@
 
 -include("imem_if.hrl").
 -include("imem_if_csv.hrl").
+-compile({parse_transform, imem_rec_pretty_pt}).
 
 -define(ClientError(__Reason), ?THROW_EXCEPTION('ClientError',__Reason)).
 -define(SystemException(__Reason),  ?THROW_EXCEPTION('SystemException',__Reason)).

--- a/src/imem_account.erl
+++ b/src/imem_account.erl
@@ -1,7 +1,5 @@
 -module(imem_account).
 
--include_lib("eunit/include/eunit.hrl").
-
 -include("imem_seco.hrl").
 
 -export([ create/2

--- a/src/imem_rec_pretty_pt.erl
+++ b/src/imem_rec_pretty_pt.erl
@@ -23,7 +23,7 @@ parse_transform(Forms, _Options) ->
         Forms2
     catch
         _:Error ->
-            ?L("parse transform failed ~p~n~p~n",
+            ?L("parse transform failed~n~p~n~p~n",
                [Error, erlang:get_stacktrace()]),
             Forms
     end.

--- a/src/imem_rec_pretty_pt.erl
+++ b/src/imem_rec_pretty_pt.erl
@@ -1,0 +1,56 @@
+-module(imem_rec_pretty_pt).
+-export([parse_transform/2]).
+
+-define(L(__F, __A), io:format(user, "{~p:~p} "__F, [?MODULE, ?LINE | __A])).
+
+parse_transform(Forms, _Options) ->
+    try
+        {Functions, Exports} =
+        lists:foldl(
+          fun({attribute,_,record,{Record,RFields}}, {Funcs, Exprts}) ->
+                  FieldNames = [case R of
+                                    {record_field,_,{atom,_,N}} -> N;
+                                    {record_field,_,{atom,_,N},_} -> N
+                                end || R <- RFields],
+                  Fun = list_to_atom(atom_to_list(Record)++"_pretty"),
+                  {[rf(Record, Fun, FieldNames) | Funcs],
+                   [{attribute,1,export,[{Fun,1}]} | Exprts]};
+             (_, Acc) -> Acc
+          end, {[], []}, Forms),
+        [{eof,_} = EOF | Rest] = lists:reverse(Forms),
+        Forms1 = lists:reverse([EOF|Functions]++Rest),
+        Forms2 = ins_exprts(Exports, Forms1),
+        Forms2
+    catch
+        _:Error ->
+            ?L("parse transform failed ~p~n~p~n",
+               [Error, erlang:get_stacktrace()]),
+            Forms
+    end.
+
+ins_exprts(Exprts, [_|_] = Forms) -> ins_exprts(Exprts, {[], Forms});
+ins_exprts([], {Heads,Tail}) -> lists:reverse(Heads)++Tail;
+ins_exprts(Exports, {Heads, [{attribute,_,export,_} = E | Tail]}) ->
+    ins_exprts([], {[E | Exports] ++ Heads, Tail});
+ins_exprts(Exports, {Heads, [F | Tail]}) ->
+    ins_exprts(Exports, {[F | Heads], Tail}).
+
+rf(Record, Fun, FieldNames) ->
+    Fmt =
+    lists:flatten(
+      ["#",atom_to_list(Record),"{",
+       string:join([atom_to_list(F)++" = ~p" || F <- FieldNames], ", "),
+       "}"]),
+    {function,1,Fun,1,
+     [{clause,1,
+       [{var,1,'S'}], [],
+       [{call,1,{remote,1,{atom,1,io_lib},{atom,1,format}},
+         [{string,1,Fmt}, f2l(Record, FieldNames)]}]
+      }]}.
+
+f2l(Record, FieldNames) ->
+    f2l(Record, FieldNames, {nil,13}).
+f2l(_, [], Acc) -> Acc;
+f2l(Record, [FieldName|FieldNames], Acc) ->
+    f2l(Record, FieldNames,
+        {cons,1,{record_field,1,{var,1,'S'},Record,{atom,1,FieldName}}, Acc}).


### PR DESCRIPTION
When an erlang record variable is printed/logged directly with ~p field names are not printed (reducing log readablity):
```erlang
> R = #ddIdxDef{}.
#ddIdxDef{id = undefined,name = undefined,type = undefined,
          pl = [],vnf = <<"fun imem_index:vnf_lcase_ascii_ne/1">>,
          iff = <<"fun imem_index:iff_true/1">>}
> io:format("~p~n", [R]).
{ddIdxDef,undefined,undefined,undefined,[],
          <<"fun imem_index:vnf_lcase_ascii_ne/1">>,
          <<"fun imem_index:iff_true/1">>}
ok
```

This PR uses parse transform to add (and export) _`recname`_`_pretty/1` function at all modules (which uses the records) to enable to record pretty printing of logs (as follows):
```erlang
(imem@127.0.0.1)5> io:format("~s~n", [imem_meta:ddIdxDef_pretty(R)]).
#ddIdxDef{id = <<"fun imem_index:iff_true/1">>,
 name = <<"fun imem_index:vnf_lcase_ascii_ne/1">>, type = [],
 pl = undefined, vnf = undefined, iff = undefined}
```