### PR TITLE
Revert "node sharded tables created by the nodes "

### DIFF
--- a/src/imem_proll.erl
+++ b/src/imem_proll.erl
@@ -35,8 +35,8 @@
         , terminate/2
         , code_change/3
         , format_status/2
-        , missing_partitions/3
-        , missing_partitions/5
+        , missing_partitions/2
+        , missing_partitions/4
         ]).
 
 start_link(Params) ->
@@ -65,14 +65,22 @@ handle_cast(_Request, State) ->
     {noreply, State}.
 
 handle_info(roll_partitioned_tables, State=#state{prollList=[]}) ->
-    % restart proll cycle by collecting list of partition name candidates
-    case ?GET_PROLL_CYCLE_WAIT of
-        PCW when (is_integer(PCW) andalso PCW >= 1000) ->
-            ProllList = get_proll_list(PCW),
-            handle_info({roll_partitioned_tables, PCW, ?GET_PROLL_ITEM_WAIT}, State#state{prollList=ProllList});
-        Other ->
-            ?Error("Partition rolling bad cycle period ~p",[Other]),
-            erlang:send_after(10000, self(), roll_partitioned_tables),
+    % checking if this is the firs node in all of nodes as
+    % partition rolling has to be done by one node at a time.
+    case node() == hd(lists:usort([node() | imem_meta:nodes()])) of
+        true ->
+            % restart proll cycle by collecting list of partition name candidates
+            case ?GET_PROLL_CYCLE_WAIT of
+                PCW when (is_integer(PCW) andalso PCW >= 1000) ->
+                    ProllList = get_proll_list(PCW),
+                    handle_info({roll_partitioned_tables, PCW, ?GET_PROLL_ITEM_WAIT}, State#state{prollList=ProllList});
+                Other ->
+                    ?Error("Partition rolling bad cycle period ~p",[Other]),
+                    erlang:send_after(10000, self(), roll_partitioned_tables),
+                    {noreply, State}
+            end;
+        false ->
+            erlang:send_after(?PROLL_FIRST_WAIT, self(), roll_partitioned_tables),
             {noreply, State}
     end;
 handle_info({roll_partitioned_tables,ProllCycleWait,ProllItemWait}, State=#state{prollList=[{TableAlias, TableName}|Rest]}) ->
@@ -126,8 +134,7 @@ get_proll_list(PCW) ->
                 {Sec,Micro} = ?TIMESTAMP,
                 Intvl = PCW div 1000,
                 CandidateTimes = [{Sec, Micro}, {Sec+Intvl, Micro}, {Sec+Intvl+Intvl, Micro}],
-                IsHeadInCluster = node() == hd(lists:usort([node() | imem_meta:nodes()])),
-                missing_partitions(AL,CandidateTimes,IsHeadInCluster)
+                missing_partitions(AL,CandidateTimes)
             catch
                 _:Reason ->
                     ?Error("Partition rolling collect failed with reason ~p~n",[Reason]),
@@ -135,33 +142,22 @@ get_proll_list(PCW) ->
             end
     end.
 
-missing_partitions(AL, CandidateTimes, IsHeadInCluster) ->
-    missing_partitions(AL, CandidateTimes, IsHeadInCluster, AL, []).
+missing_partitions(AL, CandidateTimes) ->
+    missing_partitions(AL, CandidateTimes, AL, []).
 
-missing_partitions(_, [], _, _, Acc) -> lists:usort(Acc);
-missing_partitions(AL, [_|Times], IsHeadInCluster, [], Acc) ->
-    missing_partitions(AL, Times, IsHeadInCluster, AL, Acc);
-missing_partitions(AL, [Next|Times], IsHeadInCluster, [TableAlias|Rest], Acc0) ->
+missing_partitions(_, [], _, Acc) -> lists:usort(Acc);
+missing_partitions(AL, [_|Times], [], Acc) ->
+    missing_partitions(AL, Times, AL, Acc);
+missing_partitions(AL, [Next|Times], [TableAlias|Rest], Acc0) ->
     TableName = imem_meta:partitioned_table_name(TableAlias, Next),
     Acc1 = case catch(imem_meta:check_table(TableName)) of
         ok ->   
             Acc0;
         {'ClientError',{"Table does not exist",TableName}} -> 
-            % checking if this is the first node in all of nodes as
-            % partition rolling has to be done by one node at a time.
-            case IsHeadInCluster of
-                true -> [{TableAlias, TableName}|Acc0];
-                false ->
-                    % check if the table is local table then each node have
-                    % to create their node partitioned table
-                    case imem_meta:is_local_time_partitioned_table(TableName) of
-                        true -> [{TableAlias, TableName}|Acc0];
-                        false -> Acc0
-                    end
-            end;
+            [{TableAlias, TableName}|Acc0];
         Error ->  
             ?Error("Rolling time partition collection ~p failed with reason ~p~n",[TableName, Error]),
             Acc0
     end,
-    missing_partitions(AL, [Next|Times], IsHeadInCluster, Rest, Acc1).
+    missing_partitions(AL, [Next|Times], Rest, Acc1).
 


### PR DESCRIPTION
Reverts K2InformaticsGmbH/imem#176

`imem_meta:data_nodes()` to be used instead, to detect DB islands (not erlang cluster splits)