### PR TITLE
epmd auto restart enhancements and safe mfa for dderl

### DIFF
--- a/src/imem_compiler.erl
+++ b/src/imem_compiler.erl
@@ -20,8 +20,9 @@
 % erlang:_/3
 -safe([setelement/3]).
 
-% external modules (all exported functions)
--safe([#{m => math}, #{m => lists}, #{m => proplists}, #{m => re}, #{m => maps}, #{m => binary}, #{m => string}]).
+% external erlang modules (all exported functions)
+-safe([#{m => math}, #{m => lists}, #{m => proplists}, #{m => re},
+       #{m => maps}, #{m => binary}, #{m => string}, #{m => erl_epmd}]).
 
 % external {M,F,A} s
 -safe([#{m => io, f => [format/2]},

--- a/src/imem_if_mnesia.erl
+++ b/src/imem_if_mnesia.erl
@@ -109,6 +109,8 @@
 % Functions applied with Common Test
 -export([update_xt/8]).
 
+-safe([epmd_register/0]).
+
 -define(TOUCH_SNAP(__Table),                  
             case ets:lookup(?SNAP_ETS_TAB, __Table) of
                 [__Up] ->   
@@ -963,7 +965,9 @@ init(_) ->
     % Start periodic EPMD check
     case is_pid(whereis(imem_inet_tcp_dist)) of
         true -> self() ! check_epmd;
-        _ -> ok
+        _ ->
+            ?Warn("imem_inet_tcp_dist not started, possibly missing -proto_dist"
+                  " erlang VM start parameter")
     end,
 
     {ok,#state{}}.

--- a/src/imem_inet_tcp_dist.erl
+++ b/src/imem_inet_tcp_dist.erl
@@ -9,6 +9,8 @@
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
          code_change/3, reg_info/0]).
 
+-safe([reg_info/0]).
+
 listen(Name) ->
     start(),
     R = inet_tcp_dist:listen(Name),


### PR DESCRIPTION
fixes #203

Safe API list (can be invoked through DDErl SQL `mfa()` procedure, requires permissions in `ddRole` for the executing user)
```erlang
> lists:filter(fun({erl_epmd,_,_}) -> true; (_) -> false end, imem_compiler:safe(imem_compiler)).
[{erl_epmd,code_change,3}, {erl_epmd,handle_call,3}, {erl_epmd,handle_cast,2},
 {erl_epmd,handle_info,2}, {erl_epmd,init,1}, {erl_epmd,module_info,0}, {erl_epmd,module_info,1},
 {erl_epmd,names,0}, {erl_epmd,names,1}, {erl_epmd,open,0}, {erl_epmd,open,1}, {erl_epmd,open,2},
 {erl_epmd,port_please,2}, {erl_epmd,port_please,3}, {erl_epmd,register_node,2},
 {erl_epmd,register_node,3}, {erl_epmd,start,0}, {erl_epmd,start_link,0}, {erl_epmd,stop,0},
 {erl_epmd,terminate,2}]

> imem_compiler:safe(imem_inet_tcp_dist).                                                        
[{imem_inet_tcp_dist,reg_info,0}]

> imem_compiler:safe(imem_if_mnesia).    
[{imem_if_mnesia,epmd_register,0}]
```