### PR TITLE
erlang:node/0 and imem_meta:schema/0 set as safe

### DIFF
--- a/src/imem_compiler.erl
+++ b/src/imem_compiler.erl
@@ -27,6 +27,7 @@
 % external {M,F,A} s
 -safe([#{m => io, f => [format/2]},
        #{m => io_lib, f => [format/2]},
+       #{m => erlang, f => [node/0]},
        #{m => os, f => [getenv/1,getpid,system_time,timestamp,type,version]}]).
 
 % external match {M,F,A} s

--- a/src/imem_meta.erl
+++ b/src/imem_meta.erl
@@ -286,7 +286,7 @@
 
 -export([simple_or_local_node_sharded_tables/1]).
 
--safe([log_to_db,update_index,dictionary_trigger,data_nodes,
+-safe([log_to_db,update_index,dictionary_trigger,data_nodes,schema/0,
        physical_table_name,get_tables_count,record_hash,integer_uid,time_uid]).
 
 start_link(Params) ->


### PR DESCRIPTION
these funs are used for fetching metrics information