### PR TITLE
git through port, blacklist

### DIFF
--- a/src/imem_client.erl
+++ b/src/imem_client.erl
@@ -52,7 +52,6 @@ terminate(Reason, _State) ->
 code_change(_OldVsn, State, _Extra) -> {ok, State}.
 format_status(_Opt, [_PDict, _State]) -> ok.
 
-
 get_profile(Mod, Profile, Options) ->
     case Mod:get_options(all, Profile) of
         {error, inets_not_started} ->


### PR DESCRIPTION
* `[{imem,imem,itemBlacklist}]` `ddConfig` for files or folders to blacklist from processing
* `open_port` instead of `os:cmd` to eliminate `file:set_cwd` while recursively executing git commands