### PR TITLE
Disable win32 tests on non-win32 platforms

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -48,7 +48,10 @@
 
 {erl_first_files, ["src/imem_rec_pretty_pt.erl"]}.
 
-{erl_opts, [{parse_transform, lager_transform}]}.
+{erl_opts, [
+    {parse_transform, lager_transform},
+    {platform_define, "win32", 'WIN32'}
+]}.
 
 {eunit_compile_opts, [{d, 'USE_THOUSAND_SEP'}]}.
 {eunit_opts, [

--- a/src/imem_win32.erl
+++ b/src/imem_win32.erl
@@ -87,12 +87,14 @@ missing_time(OldTime, NewTime) when OldTime == NewTime; OldTime == undefined ->
     missing_time(NewTime, os:timestamp());
 missing_time(OldTime, NewTime) when OldTime /= NewTime ->
     Start = queryPerformanceCounter(),
+    StartErl = erlang:system_time(millisecond),
     timer:sleep(10000),
+    EndErl = erlang:system_time(millisecond),
     End = queryPerformanceCounter(),
     DiffMs = (End - Start) * 1000 div queryPerformanceFrequency(),
-    SleepError = abs(10000 - DiffMs),
-    % timer:sleep/1 is +/-20ms (approx) in windows
-    ?assert(20 >= SleepError).
+    DiffErl = EndErl - StartErl,
+    Q = DiffErl/DiffMs,
+    ?assert(Q > 0.997 andalso Q < 1.003).
 
 -endif. % TEST
 -endif. % WIN32

--- a/src/imem_win32.erl
+++ b/src/imem_win32.erl
@@ -23,6 +23,7 @@ queryPerformanceCounter() ->
 queryPerformanceFrequency() ->
     exit(win32_nif_library_not_loaded).
 
+-ifdef(WIN32).
 -ifdef(TEST).
 -include_lib("eunit/include/eunit.hrl").
 
@@ -99,3 +100,4 @@ missing_time(OldTime, NewTime) when OldTime /= NewTime ->
     ?assert(10000 =< DiffMS).
 
 -endif. % TEST
+-endif. % WIN32

--- a/src/imem_win32.erl
+++ b/src/imem_win32.erl
@@ -75,10 +75,7 @@ hires_timer() ->
                 TS1 = re:replace(
                     TS, "(.*)000$", "\\g{1}"++MsStr, [{return, list}]
                 ),
-                OST1(
-                    Count - 1,
-                    [TS1 | Ts]
-                )
+                OST1(Count - 1, [TS1 | Ts])
         end
     )(100, []),
     ?assertEqual(100, length(OsTimesV2)),

--- a/src/imem_win32.erl
+++ b/src/imem_win32.erl
@@ -92,8 +92,10 @@ missing_time(OldTime, NewTime) when OldTime /= NewTime ->
     Start = queryPerformanceCounter(),
     timer:sleep(10000),
     End = queryPerformanceCounter(),
-    DiffMS = (End - Start) * 1000 div queryPerformanceFrequency(),
-    ?assert(10000 =< DiffMS).
+    DiffMs = (End - Start) * 1000 div queryPerformanceFrequency(),
+    SleepError = abs(10000 - DiffMs),
+    % timer:sleep/1 is +/-17ms in windows
+    ?assert(17 >= SleepError).
 
 -endif. % TEST
 -endif. % WIN32

--- a/src/imem_win32.erl
+++ b/src/imem_win32.erl
@@ -94,8 +94,8 @@ missing_time(OldTime, NewTime) when OldTime /= NewTime ->
     End = queryPerformanceCounter(),
     DiffMs = (End - Start) * 1000 div queryPerformanceFrequency(),
     SleepError = abs(10000 - DiffMs),
-    % timer:sleep/1 is +/-17ms in windows
-    ?assert(17 >= SleepError).
+    % timer:sleep/1 is +/-20ms (approx) in windows
+    ?assert(20 >= SleepError).
 
 -endif. % TEST
 -endif. % WIN32


### PR DESCRIPTION
fixes #280