### PR TITLE
send/receive support for ddTracer

### DIFF
--- a/include/imem_tracer.hrl
+++ b/include/imem_tracer.hrl
@@ -7,7 +7,7 @@
     trace_key               :: term(),
     event_type  = register  :: atom(),
     enable      = false     :: boolean(),
-    process                 :: term(),
+    process                 :: pid(),
     trace_node              :: atom(),
     mod         = '_'       :: atom(),
     func        = '_'       :: atom(),
@@ -18,10 +18,10 @@
     overflow    = false     :: boolean()
 }).
 -define(ddTrace, [
-    term,       % trace_key
+    integer,    % trace_key
     atom,       % event_type
     boolean,    % enable
-    term,       % process
+    pid,        % process
     atom,       % trace_node
     atom,       % mod
     atom,       % func

--- a/include/imem_tracer.hrl
+++ b/include/imem_tracer.hrl
@@ -4,7 +4,7 @@
 -include("imem_config.hrl").
 
 -record(ddTrace, {
-    trace_key               :: term(),
+    trace_key               :: integer(),
     event_type  = register  :: atom(),
     enable      = false     :: boolean(),
     process                 :: pid(),


### PR DESCRIPTION
### Send
![image](https://user-images.githubusercontent.com/913008/62823422-d6816600-bb90-11e9-8351-b7708e35842a.png)
### Receive
![image](https://user-images.githubusercontent.com/913008/62823409-c7021d00-bb90-11e9-8c13-5e1324795811.png)

### Changes
* datatype of `process` column fix to `pid` from `term`
* datatype of `trace_key` column is changed from binstr to integer
* default function for `trace_key` upgraded to handle **receive** (bypass hash calculation)
* on trace configuration `phash2` integer is directly stored in `trace_key` column rather than number base 36 `binstr`
