### PR TITLE
on demand cluster snapshotting API

### DIFF
--- a/src/imem_snap.erl
+++ b/src/imem_snap.erl
@@ -53,13 +53,7 @@
         , all_local_time_partitioned_tables/0
         ]).
 
-<<<<<<< Updated upstream
--export([ snapshot_single_to_dir/3
-        , do_cluster_snapshot/0
-        ]).
-=======
 -export([do_cluster_snapshot/0]).
->>>>>>> Stashed changes
 
 -safe([all_snap_tables,filter_candidate_list, get_snap_properties,
        set_snap_properties,snap_log,snap_err,take, do_snapshot/0]).


### PR DESCRIPTION
fixes #283 

Sample script to create large tables
```erlang
f(Chars).
Chars = lists:seq($0, $z).
f(Tables).
Tables = [list_to_atom("test"++integer_to_list(I)) || I <- lists:seq(1,10)].
lists:foreach(fun(T) ->
    spawn(fun() ->
        [begin
            Data = << <<(lists:nth(rand:uniform(length(Chars)), Chars))>> || _ <- lists:seq(1, 500 + rand:uniform(500)) >>,
            imem_meta:dirty_write(T, {T, Idx, Data}),
            if Idx rem 100 == 0 -> io:format("~p written ~p~n", [T, Idx]); true -> ok end
        end || Idx <- lists:seq(1, 1000000)]
    end)
end, Tables).
```