### PR TITLE
skvh filter_cluster_snapshot filters out everything for ['*'] as filter.

### DIFF
--- a/src/imem_snap.erl
+++ b/src/imem_snap.erl
@@ -1206,7 +1206,6 @@ f2mc(F, C) ->
 hasWild(F) -> hasWild(F, false).
 hasWild(_, true) -> true;
 hasWild([], false) -> false;
-hasWild('*',false) -> true;
 hasWild(['_'|_], false) -> true;
 hasWild(['*'|_], false) -> true;
 hasWild([H|T], false) -> hasWild(T, hasWild(H, false));
@@ -1459,27 +1458,8 @@ filters2ms_test_() ->
     [{
       lists:flatten(io_lib:format("~s : ~p", [Title, Filter])),
       fun() ->
-        case catch filters2ms(Skvh,Filter) of
-          {'EXIT', Exception} ->
-            ?debugFmt(
-              "~n~s : imem_snap:filters2ms(true,~p).~n"
-              "Expected   : ~p~n"
-              "Exception  : ~p",
-              [Title, Filter, MatchSpec, Exception]
-            ),
-            error(failed);
-          CalculatedMs ->
-            if CalculatedMs /= MatchSpec ->
-              ?debugFmt(
-                "~n~s : imem_snap:filters2ms(~p, '$1').~n"
-                "Expected   : ~p~n"
-                "Got        : ~p",
-                [Title, Filter, MatchSpec, CalculatedMs]
-              );
-              true -> ok
-            end,
-            ?assertEqual(MatchSpec, CalculatedMs)
-        end
+        CalculatedMs = filters2ms(Skvh,Filter),
+        ?assertEqual(MatchSpec, CalculatedMs)
       end
     } || {Title, Skvh, Filter, MatchSpec} <- [
       {"all skvh",   true,    ['*'],     [{'$1',[],['$_']}]},

--- a/src/imem_snap.erl
+++ b/src/imem_snap.erl
@@ -1205,6 +1205,7 @@ f2mc(F, C) ->
 hasWild(F) -> hasWild(F, false).
 hasWild(_, true) -> true;
 hasWild([], false) -> false;
+hasWild('*',false) -> true;
 hasWild(['_'|_], false) -> true;
 hasWild(['*'|_], false) -> true;
 hasWild([H|T], false) -> hasWild(T, hasWild(H, false));

--- a/src/imem_snap.erl
+++ b/src/imem_snap.erl
@@ -1452,6 +1452,42 @@ f2mc_test_() ->
         ]
     }.
 
+filters2ms_test_() ->
+  {
+    inparallel,
+    [{
+      lists:flatten(io_lib:format("~s : ~p", [Title, Filter])),
+      fun() ->
+        case catch filters2ms(true,Filter) of
+          {'EXIT', Exception} ->
+            ?debugFmt(
+              "~n~s : imem_snap:filters2ms(true,~p).~n"
+              "Expected   : ~p~n"
+              "Exception  : ~p",
+              [Title, Filter, MatchSpec, Exception]
+            ),
+            error(failed);
+          CalculatedMs ->
+            if CalculatedMs /= MatchSpec ->
+              ?debugFmt(
+                "~n~s : imem_snap:filters2ms(~p, '$1').~n"
+                "Expected   : ~p~n"
+                "Got        : ~p",
+                [Title, Filter, MatchSpec, CalculatedMs]
+              );
+              true -> ok
+            end,
+            ?assertEqual(MatchSpec, CalculatedMs)
+        end
+      end
+    } || {Title, Filter, MatchSpec} <- [
+      {"all",           ['*'],  [{#{ckey => '$1'},[],['$_']}]},
+      {"list all",      [['*']],   [{#{ckey => '$1'},[{is_list,'$1'}],['$_']}] },
+      {"all tuple",     [{'*'}],   [{#{ckey => '$1'},[{is_tuple,'$1'}],['$_']}]}
+    ]
+    ]
+  }.
+
 msrun_test_() ->
     Rows = [
         ["a"],


### PR DESCRIPTION
fixes #308 

`'*'` is not interpreted as wildcard becuse only symbols in list are considered wildcards.
added clause hasWild to interpret `'*'` as wildcard too.